### PR TITLE
Make CUDA architectures configurable from the command line 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,13 @@ else()
     enable_language(CUDA)
     
     set_target_properties(iPIC3Dlib PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-    set_property(TARGET iPIC3Dlib PROPERTY CUDA_ARCHITECTURES 75) # required for double atomicadd
+    # Cache variable so users can override at configure time
+    set(CMAKE_CUDA_ARCHITECTURES "75" CACHE STRING
+        "Semicolon-separated CUDA architectures (e.g. 70;75;80;90;native). Default 75 if unset.")
+    if(NOT CMAKE_CUDA_ARCHITECTURES OR CMAKE_CUDA_ARCHITECTURES STREQUAL "")
+        set(CMAKE_CUDA_ARCHITECTURES "75")
+    endif()
+    set_property(TARGET iPIC3Dlib PROPERTY CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}") # required for double atomicadd
     set_property(TARGET iPIC3Dlib PROPERTY CUDA_STANDARD 17)
     set_property(TARGET iPIC3Dlib PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
     #   set_property(TARGET iPIC3Dlib PROPERTY LINK_OPTIONS -fno-lto)


### PR DESCRIPTION
The `CMakeLists.txt` currently hardcodes `CUDA_ARCHITECTURES=75`. While the cuda runtime JIT can generate SASS from embedded PTX for other GPUs, this caused inaccurate or failed Nsight profiling (metrics and source correlation) until compiled with the matching architecture list. This PR replaces the hardcoded value with a cached `CMAKE_CUDA_ARCHITECTURES` variable (default 75). Users can now request a specific or multiple archs (e.g. 70;75;80;90) from the command line during the configuration step. 

**Usage examples**:
`cmake -DCMAKE_CUDA_ARCHITECTURES="80" ..`
